### PR TITLE
Silence error messages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,9 +22,9 @@ task :handlebars do
 end
 
 task :pdf do
-  `mkdir contracts`
+  `mkdir -p contracts`
   ['cp', 'cgv'].each do |file|
-    `rm contracts/#{file}.pdf`
+    `rm -f contracts/#{file}.pdf`
     `gimli -f tmp/#{file}.md -o contracts`
   end
 end


### PR DESCRIPTION
Remove warnings when `contracts` directory already exists or when `contracts/(cgv|cp).pdf` do not exist