### PR TITLE
Prepend the gimli command with bundle exec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ task :pdf do
   `mkdir -p contracts`
   ['cp', 'cgv', 'cga'].each do |file|
     `rm -f contracts/#{file}.pdf`
-    `gimli -f tmp/#{file}.md -o contracts`
+    `bundle exec gimli -f tmp/#{file}.md -o contracts`
   end
   puts 'Vos fichiers sont dans le dossier contracts'
 end


### PR DESCRIPTION
To avoid the error `Errno::ENOENT: No such file or directory - gimli` we should prepend the gimli command with `bundle exec`.